### PR TITLE
Add RSS collector and web UI for AI news

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.pyc
+.env
+.venv/
+.env.local
+.DS_Store
+data/*.db
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,77 @@
-# ai_news_collections
-ai_news_collections
+# AI News Collections
+
+该项目用于每天聚合 [smol.ai](https://news.smol.ai/rss.xml) 的 AI 新闻，使用大模型进行中文翻译总结，并通过一个简单的前端页面展示结果。
+
+## 功能概览
+
+- `backend/collector.py`：从 RSS 源抓取新闻，调用 OpenAI 大模型翻译并生成中文摘要，存储到 SQLite 数据库中。
+- `backend/api.py`：FastAPI 服务，提供 REST API 和网页视图来浏览已存储的新闻。
+- 前端模板（`templates/index.html` + `static/styles.css`）展示每日新闻列表，优先显示中文摘要。
+
+## 环境准备
+
+1. 安装依赖：
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. 配置 OpenAI API Key：
+
+   ```bash
+   export OPENAI_API_KEY="sk-..."
+   ```
+
+## 使用方式
+
+### 采集每日新闻
+
+可以通过以下命令手动或配合定时任务（如 cron）执行：
+
+```bash
+python -m backend.collector
+```
+
+常用参数：
+
+- `--skip-llm`：跳过翻译，只保存原始摘要。
+- `--dry-run`：测试运行，不写入数据库。
+- `--limit`：限制本次处理的新闻数量。
+
+默认数据会写入 `data/articles.db`。
+
+### 启动展示服务
+
+```bash
+uvicorn backend.api:app --reload
+```
+
+访问 `http://127.0.0.1:8000/` 即可查看每日 AI 新闻摘要。
+
+也可以访问 `http://127.0.0.1:8000/api/articles` 以 JSON 格式获取数据，方便后续集成。
+
+## 项目结构
+
+```
+ai_news_collections/
+├── backend/
+│   ├── __init__.py
+│   ├── api.py             # FastAPI 应用
+│   ├── collector.py       # RSS 抓取与翻译逻辑
+│   ├── db.py              # SQLite 数据库工具
+│   └── llm.py             # OpenAI LLM 调用封装
+├── data/
+│   └── articles.db        # 运行后生成的数据库（初始为空）
+├── requirements.txt
+├── static/
+│   └── styles.css         # 页面样式
+├── templates/
+│   └── index.html         # 列表展示页面
+└── README.md
+```
+
+## 后续扩展建议
+
+- 接入更多 AI 新闻来源或支持自定义 RSS 列表。
+- 为文章添加标签、搜索和分页功能。
+- 将翻译摘要缓存为 Markdown，支持前端富文本渲染。

--- a/backend/api.py
+++ b/backend/api.py
@@ -1,0 +1,54 @@
+"""FastAPI application that exposes the aggregated AI news."""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
+
+from . import db
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+TEMPLATES_DIR = BASE_DIR / "templates"
+STATIC_DIR = BASE_DIR / "static"
+
+app = FastAPI(title="AI News Collections")
+app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+templates = Jinja2Templates(directory=TEMPLATES_DIR)
+
+
+@app.on_event("startup")
+def on_startup() -> None:
+    db.init_db()
+
+
+@app.get("/api/articles")
+def list_articles(limit: int = 50) -> List[dict]:
+    articles = [
+        {
+            "title": article.title,
+            "link": article.link,
+            "published_at": article.published_at,
+            "source": article.source,
+            "original_summary": article.original_summary,
+            "translated_summary": article.translated_summary,
+            "created_at": article.created_at.isoformat(),
+        }
+        for article in db.iter_recent_articles(limit)
+    ]
+    return articles
+
+
+@app.get("/", response_class=HTMLResponse)
+def index(request: Request, limit: int = 50) -> HTMLResponse:
+    articles = list(db.iter_recent_articles(limit))
+    return templates.TemplateResponse(
+        "index.html",
+        {
+            "request": request,
+            "articles": articles,
+        },
+    )

--- a/backend/collector.py
+++ b/backend/collector.py
@@ -1,0 +1,183 @@
+"""RSS collector that fetches AI news and stores translated summaries."""
+from __future__ import annotations
+
+import argparse
+import logging
+from dataclasses import dataclass
+from typing import Iterable, Optional
+from urllib.request import urlopen
+from xml.etree import ElementTree as ET
+
+from . import db
+from .llm import LLMClient, MissingAPIKeyError, MissingLLMLibraryError
+
+LOGGER = logging.getLogger(__name__)
+
+XML_NAMESPACES = {
+    "content": "http://purl.org/rss/1.0/modules/content/",
+    "atom": "http://www.w3.org/2005/Atom",
+}
+
+
+@dataclass(slots=True)
+class FeedEntry:
+    title: str
+    link: str
+    published: Optional[str]
+    updated: Optional[str]
+    summary: Optional[str]
+    contents: list[str]
+    source_title: Optional[str]
+
+
+def _text(element: Optional[ET.Element]) -> Optional[str]:
+    if element is None or element.text is None:
+        return None
+    return element.text.strip()
+
+
+def _parse_feed(feed_url: str) -> Iterable[FeedEntry]:
+    with urlopen(feed_url) as response:
+        data = response.read()
+
+    root = ET.fromstring(data)
+    items = root.findall(".//item")
+    entries: list[FeedEntry] = []
+
+    for item in items:
+        title = _text(item.find("title")) or "Untitled"
+        link = _text(item.find("link")) or ""
+        published = _text(item.find("pubDate"))
+        updated = _text(item.find("updated")) or _text(
+            item.find("atom:updated", XML_NAMESPACES)
+        )
+        summary = _text(item.find("description"))
+        contents = [
+            text
+            for node in item.findall("content:encoded", XML_NAMESPACES)
+            if (text := _text(node))
+        ]
+        source_title = _text(item.find("source")) or _text(
+            item.find("atom:source/atom:title", XML_NAMESPACES)
+        )
+
+        entries.append(
+            FeedEntry(
+                title=title,
+                link=link,
+                published=published,
+                updated=updated,
+                summary=summary,
+                contents=contents,
+                source_title=source_title,
+            )
+        )
+
+    return entries
+
+
+def _build_summary_text(entry: FeedEntry) -> str:
+    parts = []
+    if entry.summary:
+        parts.append(entry.summary)
+    parts.extend(entry.contents)
+    return "\n\n".join(parts)
+
+
+def process_feed(
+    feed_url: str,
+    *,
+    llm_client: Optional[LLMClient],
+    limit: Optional[int] = None,
+    dry_run: bool = False,
+) -> int:
+    """Fetch the feed and insert new articles, returning the number stored."""
+    LOGGER.info("Fetching feed %s", feed_url)
+    entries = _parse_feed(feed_url)
+    count = 0
+
+    for entry in entries:
+        if limit is not None and count >= limit:
+            break
+
+        link = entry.link
+        title = entry.title
+        if not link:
+            LOGGER.debug("Skipping entry without link: %s", title)
+            continue
+        if db.article_exists(link):
+            LOGGER.debug("Skipping existing article: %s", link)
+            continue
+
+        published = entry.published or entry.updated
+        source = entry.source_title
+        original_summary = entry.summary
+        translated_summary = None
+
+        if llm_client is not None:
+            LOGGER.info("Translating article via LLM: %s", title)
+            summary_text = _build_summary_text(entry)
+            translated_summary = llm_client.translate_and_summarise(
+                title=title,
+                summary=summary_text or original_summary or "",
+                link=link,
+            )
+        else:
+            LOGGER.info("LLM disabled; skipping translation for %s", title)
+
+        if dry_run:
+            LOGGER.info("Dry run: would store article %s", title)
+            count += 1
+            continue
+
+        db.insert_article(
+            title=title,
+            link=link,
+            published_at=published,
+            source=source,
+            original_summary=original_summary,
+            translated_summary=translated_summary,
+        )
+        count += 1
+
+    return count
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Collect and translate AI news articles")
+    parser.add_argument("feed_url", help="RSS feed URL", nargs="?", default="https://news.smol.ai/rss.xml")
+    parser.add_argument("--limit", type=int, help="Limit the number of processed entries")
+    parser.add_argument("--skip-llm", action="store_true", help="Skip translation and only store metadata")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch and translate without writing to the database")
+    parser.add_argument("--model", default="gpt-4o-mini", help="OpenAI model name")
+    parser.add_argument("--temperature", type=float, default=0.2, help="Sampling temperature for the model")
+    return parser
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="[%(levelname)s] %(message)s")
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+
+    llm_client: Optional[LLMClient]
+    if args.skip_llm:
+        llm_client = None
+    else:
+        try:
+            llm_client = LLMClient(model=args.model, temperature=args.temperature)
+        except (MissingAPIKeyError, MissingLLMLibraryError) as exc:  # pragma: no cover - CLI behaviour
+            parser.error(str(exc))
+            return 2
+
+    inserted = process_feed(
+        args.feed_url,
+        llm_client=llm_client,
+        limit=args.limit,
+        dry_run=args.dry_run,
+    )
+    LOGGER.info("Processed %s new articles", inserted)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI entrypoint
+    raise SystemExit(main())

--- a/backend/db.py
+++ b/backend/db.py
@@ -1,0 +1,126 @@
+"""Database utilities for storing aggregated AI news articles."""
+from __future__ import annotations
+
+import sqlite3
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Generator, Iterable, Optional
+
+DATA_DIR = Path(__file__).resolve().parent.parent / "data"
+DB_PATH = DATA_DIR / "articles.db"
+
+
+def init_db() -> None:
+    """Ensure the SQLite database and articles table exist."""
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(DB_PATH) as conn:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS articles (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                title TEXT NOT NULL,
+                link TEXT NOT NULL UNIQUE,
+                published_at TEXT,
+                source TEXT,
+                original_summary TEXT,
+                translated_summary TEXT,
+                created_at TEXT NOT NULL
+            )
+            """
+        )
+        conn.commit()
+
+
+@contextmanager
+def get_connection() -> Generator[sqlite3.Connection, None, None]:
+    """Context manager that yields a SQLite connection with row factory."""
+    init_db()
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+@dataclass(slots=True)
+class Article:
+    """Data container representing a stored news article."""
+
+    title: str
+    link: str
+    published_at: Optional[str]
+    source: Optional[str]
+    original_summary: Optional[str]
+    translated_summary: Optional[str]
+    created_at: datetime
+
+    @classmethod
+    def from_row(cls, row: sqlite3.Row) -> "Article":
+        return cls(
+            title=row["title"],
+            link=row["link"],
+            published_at=row["published_at"],
+            source=row["source"],
+            original_summary=row["original_summary"],
+            translated_summary=row["translated_summary"],
+            created_at=datetime.fromisoformat(row["created_at"]),
+        )
+
+
+def article_exists(link: str) -> bool:
+    """Return True if an article with the given link is already stored."""
+    with get_connection() as conn:
+        cur = conn.execute("SELECT 1 FROM articles WHERE link = ? LIMIT 1", (link,))
+        return cur.fetchone() is not None
+
+
+def insert_article(
+    *,
+    title: str,
+    link: str,
+    published_at: Optional[str],
+    source: Optional[str],
+    original_summary: Optional[str],
+    translated_summary: Optional[str],
+) -> None:
+    """Persist a new article record to the database."""
+    with get_connection() as conn:
+        conn.execute(
+            """
+            INSERT OR IGNORE INTO articles (
+                title,
+                link,
+                published_at,
+                source,
+                original_summary,
+                translated_summary,
+                created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                title,
+                link,
+                published_at,
+                source,
+                original_summary,
+                translated_summary,
+                datetime.utcnow().isoformat(timespec="seconds"),
+            ),
+        )
+        conn.commit()
+
+
+def iter_recent_articles(limit: Optional[int] = None) -> Iterable[Article]:
+    """Yield stored articles ordered by creation date descending."""
+    query = "SELECT * FROM articles ORDER BY created_at DESC"
+    params: tuple[object, ...] = ()
+    if limit is not None:
+        query += " LIMIT ?"
+        params = (limit,)
+
+    with get_connection() as conn:
+        for row in conn.execute(query, params):
+            yield Article.from_row(row)

--- a/backend/llm.py
+++ b/backend/llm.py
@@ -1,0 +1,66 @@
+"""Abstraction for calling an LLM to translate and summarise news."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    from openai import OpenAI
+except ImportError:  # pragma: no cover - optional dependency
+    OpenAI = None  # type: ignore
+
+
+class MissingLLMLibraryError(RuntimeError):
+    """Raised when the OpenAI SDK is not installed."""
+
+
+class MissingAPIKeyError(RuntimeError):
+    """Raised when the OpenAI API key is missing."""
+
+
+@dataclass
+class LLMClient:
+    """Simple wrapper around the OpenAI chat completions API."""
+
+    model: str = "gpt-4o-mini"
+    api_key: Optional[str] = None
+    temperature: float = 0.2
+
+    def __post_init__(self) -> None:
+        if OpenAI is None:
+            raise MissingLLMLibraryError(
+                "The openai package is required. Install it via `pip install openai`."
+            )
+
+        key = self.api_key or os.getenv("OPENAI_API_KEY")
+        if not key:
+            raise MissingAPIKeyError(
+                "OPENAI_API_KEY environment variable is not set. "
+                "Set it before running the collector or pass api_key explicitly."
+            )
+
+        self._client = OpenAI(api_key=key)
+
+    def translate_and_summarise(self, title: str, summary: str, link: str) -> str:
+        """Translate and summarise an article into Chinese using the LLM."""
+        prompt = (
+            "You are an assistant that summarises English AI news into concise, "
+            "professionally written Simplified Chinese."
+        )
+        user_message = (
+            "请阅读下面的AI新闻条目，基于标题、原始摘要和链接内容，"
+            "输出一个不超过120字的中文摘要。摘要需要包含关键信息，并保持中立客观的语气。\n\n"
+            f"标题: {title}\n"
+            f"英文摘要: {summary or '无'}\n"
+            f"新闻链接: {link}"
+        )
+        response = self._client.chat.completions.create(
+            model=self.model,
+            temperature=self.temperature,
+            messages=[
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": user_message},
+            ],
+        )
+        return response.choices[0].message.content.strip()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.111.0
+uvicorn[standard]==0.29.0
+openai==1.30.1
+jinja2==3.1.4

--- a/static/styles.css
+++ b/static/styles.css
@@ -1,0 +1,116 @@
+:root {
+  color-scheme: light dark;
+  font-family: "Noto Sans SC", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+  background-color: #f8fafc;
+  color: #111827;
+}
+
+body {
+  margin: 0;
+  padding: 0;
+  background: linear-gradient(180deg, #f8fafc 0%, #e2e8f0 100%);
+  min-height: 100vh;
+}
+
+.page-header,
+.page-footer {
+  text-align: center;
+  padding: 2rem 1rem;
+}
+
+.page-header h1 {
+  margin-bottom: 0.25rem;
+  font-size: clamp(2rem, 5vw, 2.75rem);
+}
+
+.page-header p,
+.page-footer p {
+  margin: 0;
+  color: #475569;
+}
+
+main {
+  max-width: 920px;
+  margin: 0 auto;
+  padding: 0 1rem 3rem;
+}
+
+.articles {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.article-card {
+  background: rgba(255, 255, 255, 0.85);
+  box-shadow: 0 15px 35px -25px rgba(15, 23, 42, 0.6);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  backdrop-filter: blur(6px);
+}
+
+.article-card h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1.5rem;
+}
+
+.article-card h2 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.article-card h2 a:hover,
+.article-card h2 a:focus {
+  text-decoration: underline;
+}
+
+.meta {
+  font-size: 0.9rem;
+  color: #64748b;
+  margin-bottom: 0.75rem;
+}
+
+.summary {
+  margin: 0;
+  line-height: 1.6;
+  white-space: pre-wrap;
+}
+
+.summary.original {
+  color: #0f172a;
+  opacity: 0.75;
+}
+
+.summary.empty {
+  color: #94a3b8;
+}
+
+.empty-state {
+  text-align: center;
+  color: #94a3b8;
+  padding: 4rem 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    background-color: #0f172a;
+    color: #e2e8f0;
+  }
+
+  body {
+    background: radial-gradient(circle at top, #1e293b, #0f172a);
+    color: #e2e8f0;
+  }
+
+  .article-card {
+    background: rgba(15, 23, 42, 0.75);
+    box-shadow: 0 20px 40px -30px rgba(148, 163, 184, 0.5);
+  }
+
+  .summary.original {
+    color: #cbd5f5;
+  }
+
+  .summary.empty {
+    color: #475569;
+  }
+}

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>每日AI新闻摘要</title>
+    <link rel="stylesheet" href="/static/styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <h1>每日 AI 新闻摘要</h1>
+      <p>数据来源：<a href="https://news.smol.ai/rss.xml" target="_blank" rel="noopener">smol.ai News</a></p>
+    </header>
+
+    <main>
+      {% if articles %}
+      <section class="articles">
+        {% for article in articles %}
+        <article class="article-card">
+          <h2><a href="{{ article.link }}" target="_blank" rel="noopener">{{ article.title }}</a></h2>
+          {% if article.published_at %}
+          <p class="meta">发布时间：{{ article.published_at }}</p>
+          {% endif %}
+          {% if article.translated_summary %}
+          <p class="summary">{{ article.translated_summary }}</p>
+          {% elif article.original_summary %}
+          <p class="summary original">原文摘要：{{ article.original_summary }}</p>
+          {% else %}
+          <p class="summary empty">暂无摘要</p>
+          {% endif %}
+        </article>
+        {% endfor %}
+      </section>
+      {% else %}
+      <p class="empty-state">数据库中暂时没有新闻，请先运行采集脚本。</p>
+      {% endif %}
+    </main>
+
+    <footer class="page-footer">
+      <p>可使用 <code>python -m backend.collector</code> 按日更新数据。</p>
+    </footer>
+  </body>
+</html>

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from backend import db
+from backend.collector import FeedEntry, _build_summary_text
+
+
+def setup_temp_db(tmp_path: Path) -> None:
+    db.DATA_DIR = tmp_path
+    db.DB_PATH = tmp_path / "test.db"
+    db.init_db()
+
+
+def test_insert_and_fetch_articles(tmp_path):
+    setup_temp_db(tmp_path)
+    assert list(db.iter_recent_articles()) == []
+
+    db.insert_article(
+        title="Test",
+        link="https://example.com",
+        published_at="2024-01-01",
+        source="Example",
+        original_summary="Original",
+        translated_summary="Translated",
+    )
+
+    articles = list(db.iter_recent_articles())
+    assert len(articles) == 1
+    article = articles[0]
+    assert article.title == "Test"
+    assert article.link == "https://example.com"
+    assert article.translated_summary == "Translated"
+
+
+def test_article_exists(tmp_path):
+    setup_temp_db(tmp_path)
+    assert not db.article_exists("https://example.com")
+    db.insert_article(
+        title="Test",
+        link="https://example.com",
+        published_at=None,
+        source=None,
+        original_summary=None,
+        translated_summary=None,
+    )
+    assert db.article_exists("https://example.com")
+
+
+def test_build_summary_text_prefers_all_content():
+    entry = FeedEntry(
+        title="Title",
+        link="https://example.com",
+        published=None,
+        updated=None,
+        summary="Short",
+        contents=["Long form content"],
+        source_title=None,
+    )
+    result = _build_summary_text(entry)
+    assert "Short" in result and "Long form content" in result


### PR DESCRIPTION
## Summary
- add a SQLite-backed storage layer for aggregated AI news articles
- implement an RSS collector that can translate summaries via an OpenAI model
- build a FastAPI-powered web UI with styling and usage documentation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68d4c79b7960832d9e951372c03626b5